### PR TITLE
 Fix monaco-editor worker script loading

### DIFF
--- a/packages/eth-extended/CHANGELOG.md
+++ b/packages/eth-extended/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.1
+
+- Fix contract accordion console errors related to monaco-editor
+
 # v2.1.0
 
 - Add company link module (toolbar, topbar)

--- a/packages/eth-lite/CHANGELOG.md
+++ b/packages/eth-lite/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.0.1
+
+- Fix contract accordion console errors related to monaco-editor
+
 # v2.0.0
 
 - Update search adapter to use new search interface, returning an array of results.

--- a/src/app/shared/component/sourceCode/SourceCode.tsx
+++ b/src/app/shared/component/sourceCode/SourceCode.tsx
@@ -24,15 +24,13 @@ export class SourceCode extends React.Component<ISourceCodeProps> {
                 // Monkey patch the getWorkerUrl method defined by monaco-editor-webpack-plugin
                 // to allow cross-origin worker loading
                 let oldGetWorkerUrl = (self as any).MonacoEnvironment.getWorkerUrl;
-                (self as any).MonacoEnvironment = {
-                    getWorkerUrl(moduleId: string, label: string) {
-                        let workerUrl = oldGetWorkerUrl(moduleId, label).replace("\\", "/");
-                        return "data:text/javascript;charset=utf-8," + encodeURIComponent(
-                            `importScripts('${
-                                workerUrl.match(/^https?:/) ? workerUrl : location.origin + "/" + workerUrl
-                            }');`
-                        );
-                    }
+                (self as any).MonacoEnvironment.getWorkerUrl = (moduleId: string, label: string) => {
+                    let workerUrl = oldGetWorkerUrl(moduleId, label).replace("\\", "/");
+                    return "data:text/javascript;charset=utf-8," + encodeURIComponent(
+                        `importScripts('${
+                            workerUrl.match(/^https?:/) ? workerUrl : location.origin + "/" + workerUrl
+                        }');`
+                    );
                 };
             }
 

--- a/src/app/shared/component/sourceCode/SourceCode.tsx
+++ b/src/app/shared/component/sourceCode/SourceCode.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+let monacoEnvPatched = false;
+
 export interface ISourceCodeProps {
     monaco: typeof import("monaco-editor/esm/vs/editor/editor.api");
     options: import("monaco-editor/esm/vs/editor/editor.api").editor.IEditorConstructionOptions;
@@ -17,6 +19,23 @@ export class SourceCode extends React.Component<ISourceCodeProps> {
 
     componentDidMount() {
         setTimeout(async () => {
+            if (!monacoEnvPatched) {
+                monacoEnvPatched = true;
+                // Monkey patch the getWorkerUrl method defined by monaco-editor-webpack-plugin
+                // to allow cross-origin worker loading
+                let oldGetWorkerUrl = (self as any).MonacoEnvironment.getWorkerUrl;
+                (self as any).MonacoEnvironment = {
+                    getWorkerUrl(moduleId: string, label: string) {
+                        let workerUrl = oldGetWorkerUrl(moduleId, label).replace("\\", "/");
+                        return "data:text/javascript;charset=utf-8," + encodeURIComponent(
+                            `importScripts('${
+                                workerUrl.match(/^https?:/) ? workerUrl : location.origin + "/" + workerUrl
+                            }');`
+                        );
+                    }
+                };
+            }
+
             this.editor = this.props.monaco.editor.create(this.el, this.props.options);
         });
     }


### PR DESCRIPTION
- Cross-domain web workers can only be loaded with a data url workaround